### PR TITLE
Check for existing PDF mime type before registering it.

### DIFF
--- a/lib/princely/rails.rb
+++ b/lib/princely/rails.rb
@@ -1,6 +1,8 @@
 require File.dirname(__FILE__) + '/../princely'
 require 'princely/pdf_helper'
 
-Mime::Type.register 'application/pdf', :pdf
+if Mime::Type.lookup_by_extension(:pdf) != 'application/pdf'
+  Mime::Type.register 'application/pdf', :pdf
+end
 
 ActionController::Base.send(:include, PdfHelper)


### PR DESCRIPTION
Check for existing PDF mime type before registering it.